### PR TITLE
Expose mariaDB port

### DIFF
--- a/Template/Stack/nextcloud.yml
+++ b/Template/Stack/nextcloud.yml
@@ -26,6 +26,8 @@ services:
       - MYSQL_DATABASE=nextcloud_db
       - MYSQL_USER=nextcloud
       - MYSQL_PASSWORD=${DATABASE_PASSWORD}
+    ports:
+      - 3306:3306
     volumes:
       - /portainer/AppData/Config/Nextcloud/DB:/config
     restart: unless-stopped


### PR DESCRIPTION
Hi,

Thanks for the great work on maintaining these portainer templates, the work is invaluable in making usable for the wider community!

It seems I might be the first one to use the nextcloud template in a while and finding some issues making the app container talk to the mariaDB container, since the MariaDB container port isn't exposed, which prevents the nextcloud container from accessing it.

Regards,
Michael