### PR TITLE
fix homechart url

### DIFF
--- a/Template/Stack/homechart.yml
+++ b/Template/Stack/homechart.yml
@@ -11,7 +11,7 @@ services:
       HOMECHART_POSTGRESQL_HOSTNAME: postgres
       HOMECHART_POSTGRESQL_PASSWORD: postgres
       HOMECHART_POSTGRESQL_USERNAME: postgres
-    image: candiddev/homechart:latest
+    image: ghcr.io/candiddev/homechart:latest
     ports:
       - "3030:3000"
     restart: always


### PR DESCRIPTION
for homechart, the image in the template right now is `candiddev/homechart:latest` but should be `ghcr.io/candiddev/homechart:latest`.

Tested successfully. 

See [official documentation](https://docs.homechart.app/installing-homechart/server/on-your-network/installation/container-install/) where the correct image name is cited
