### PR TITLE
Update actual.yml

### DIFF
--- a/Template/Stack/actual.yml
+++ b/Template/Stack/actual.yml
@@ -6,5 +6,5 @@ services:
             - 5007:5006
         volumes:
             - /portainer/Files/AppData/Config/actual:/data
-        image: 'jlongster/actual-server:latest'
+        image: 'actualbudget/actual-server:latest'
         restart: unless-stopped


### PR DESCRIPTION
The image `jlongster/actual-server:latest` is deprecated since the owner [open sourced Actual](https://actualbudget.com/open-source). 

The new image is `actualbudget/actual-server:latest`.